### PR TITLE
added avro wrappers so everything is fully typed

### DIFF
--- a/src/generators/generateAvroWrapper.ts
+++ b/src/generators/generateAvroWrapper.ts
@@ -1,0 +1,75 @@
+import { RecordType, Field, isEnumType, isRecordType, isArrayType, isUnion, isMapType, isPrimitive } from '../model'
+import {
+  avroWrapperName,
+  qEnumName,
+  resolveReference,
+  qAvroWrapperName,
+  qualifiedName,
+  enumName,
+  className,
+} from './utils'
+import { GeneratorContext } from './typings'
+import { generatePrimitive } from './generateFieldType'
+
+function getTypeKey(type: any, context: GeneratorContext): string {
+  if (isPrimitive(type)) {
+    return type
+  } else if (isEnumType(type)) {
+    return qualifiedName(type, enumName)
+  } else if (isRecordType(type)) {
+    return qualifiedName(type, className)
+  } else if (isArrayType(type) || isMapType(type)) {
+    return type.type
+  } else if (typeof type === 'string') {
+    return getTypeKey(resolveReference(type, context), context)
+  }
+  throw new TypeError(`Unknown type`)
+}
+
+function quoteTypeKey(key: string): string {
+  if (key.indexOf('.') >= 0) {
+    return `'${key}'`
+  }
+  return key
+}
+
+export function generateAvroWrapperFieldType(type: any, context: GeneratorContext): string {
+  if (isPrimitive(type)) {
+    return generatePrimitive(type)
+  } else if (isEnumType(type)) {
+    return qEnumName(type, context)
+  } else if (isRecordType(type)) {
+    return qAvroWrapperName(type, context)
+  } else if (isArrayType(type)) {
+    const itemsType = generateAvroWrapperFieldType(type.items, context)
+    return isUnion(type.items) && type.items.length > 1 ? `(${itemsType})[]` : `${itemsType}[]`
+  } else if (isUnion(type)) {
+    if (type.length === 1) {
+      return generateAvroWrapperFieldType(type[0], context)
+    }
+    const withoutNull = type.filter((t) => (t as any) !== 'null')
+    const hasNull = withoutNull.length !== type.length
+    const fields = withoutNull
+      .map((t) => `${quoteTypeKey(getTypeKey(t, context))}?: ${generateAvroWrapperFieldType(t, context)}`)
+      .join(',\n')
+    return `{
+      ${fields}
+    }${hasNull ? '| null' : ''}`
+  } else if (isMapType(type)) {
+    return `{ [index:string]:${generateAvroWrapperFieldType(type.values, context)} }`
+  } else if (typeof type === 'string') {
+    return generateAvroWrapperFieldType(resolveReference(type, context), context)
+  } else {
+    throw new TypeError(`not ready for type ${type}`)
+  }
+}
+
+function generateFieldDeclaration(field: Field, context: GeneratorContext): string {
+  return `${field.name}: ${generateAvroWrapperFieldType(field.type, context)}`
+}
+
+export function generateAvroWrapper(type: RecordType, context: GeneratorContext): string {
+  return `export interface ${avroWrapperName(type)} {
+    ${type.fields.map((field) => generateFieldDeclaration(field, context)).join('\n')}
+  }`
+}

--- a/src/generators/generateContent.ts
+++ b/src/generators/generateContent.ts
@@ -1,6 +1,7 @@
 import { generateInterface } from './generateInterface'
 import { generateClass } from './generateClass'
 import { generateEnumType } from './generateEnum'
+import { generateAvroWrapper } from './generateAvroWrapper'
 import { alphaComparator } from './utils'
 import { RecordType, EnumType } from '../model'
 import { GeneratorContext } from './typings'
@@ -11,10 +12,12 @@ export function generateContent(recordTypes: RecordType[], enumTypes: EnumType[]
 
   const enums = sortedEnums.map((t) => generateEnumType(t, context))
   const interfaces = sortedRecords.map((t) => generateInterface(t, context))
+  const avroWrappers = sortedRecords.map((t) => generateAvroWrapper(t, context))
   const classes = sortedRecords.map((t) => generateClass(t, context))
   return []
     .concat(enums)
     .concat(interfaces)
+    .concat(avroWrappers)
     .concat(classes)
     .join('\n')
 }

--- a/src/generators/generateDeserialize.ts
+++ b/src/generators/generateDeserialize.ts
@@ -7,6 +7,7 @@ import {
   qualifiedName,
   resolveReference,
   qClassName,
+  avroWrapperName,
 } from './utils'
 import { generateFieldType } from './generateFieldType'
 import { GeneratorContext } from './typings'
@@ -30,11 +31,11 @@ function generateAssignmentValue(type: any, context: GeneratorContext, inputVar:
     return generateAssignmentValue(resolveReference(type, context), context, inputVar)
   } else if (isArrayType(type)) {
     if (isUnion(type.items) && type.items.length > 1) {
-      return `${inputVar}.map((e: any) => {
+      return `${inputVar}.map((e) => {
         return ${generateAssignmentValue(type.items, context, 'e')}
       })`
     }
-    return `${inputVar}.map((e: any) => ${generateAssignmentValue(type.items, context, 'e')})`
+    return `${inputVar}.map((e) => ${generateAssignmentValue(type.items, context, 'e')})`
   } else if (isUnion(type)) {
     if (type.length === 1) {
       return generateAssignmentValue(type[0], context, inputVar)
@@ -75,7 +76,7 @@ function generateDeserializeFieldAssignment(field: Field, context: GeneratorCont
 }
 
 export function generateDeserialize(type: RecordType, context: GeneratorContext) {
-  return `public static deserialize(input: any): ${className(type)} {
+  return `public static deserialize(input: ${avroWrapperName(type)}): ${className(type)} {
     return new ${className(type)}({
       ${type.fields.map((f) => generateDeserializeFieldAssignment(f, context)).join('\n')}
     })

--- a/src/generators/generateFieldType.ts
+++ b/src/generators/generateFieldType.ts
@@ -2,7 +2,7 @@ import { resolveReference, qInterfaceName, qEnumName } from './utils'
 import { isRecordType, isPrimitive, isEnumType, isArrayType, isMapType } from '../model'
 import { GeneratorContext } from './typings'
 
-function generatePrimitive(avroType: string): string {
+export function generatePrimitive(avroType: string): string {
   switch (avroType) {
     case 'long':
     case 'int':

--- a/src/generators/generateSerialize.ts
+++ b/src/generators/generateSerialize.ts
@@ -7,8 +7,10 @@ import {
   resolveReference,
   qClassName,
   className,
+  avroWrapperName,
 } from './utils'
 import { GeneratorContext } from './typings'
+import { generateAvroWrapperFieldType } from './generateAvroWrapper'
 
 function getKey(t: any, context: GeneratorContext) {
   if (!isPrimitive(t) && typeof t === 'string') {
@@ -92,7 +94,7 @@ function generateAssignmentValue(type: any, context: GeneratorContext, inputVar:
     return asSelfExecuting(block)
   } else if (isMapType(type)) {
     const mapParsingStatements = `const keys = Object.keys(${inputVar});
-    const output: any = {};
+    const output: ${generateAvroWrapperFieldType(type, context)} = {};
     for(let i = 0; i < keys.length; i +=1 ) {
       const mapKey = keys[i];
       const mapValue = ${inputVar}[mapKey];
@@ -112,7 +114,7 @@ function generateFieldAssginment(field: Field, context: GeneratorContext): strin
 }
 
 export function generateSerialize(type: RecordType, context: GeneratorContext): string {
-  return `public static serialize(input: ${className(type)}): object {
+  return `public static serialize(input: ${className(type)}): ${avroWrapperName(type)} {
     return {
       ${type.fields.map((field) => generateFieldAssginment(field, context))}
     }

--- a/src/generators/utils.ts
+++ b/src/generators/utils.ts
@@ -14,6 +14,10 @@ export function interfaceName(type: RecordType) {
   return `I${type.name}`
 }
 
+export function avroWrapperName(type: RecordType) {
+  return `I${type.name}AvroWrapper`
+}
+
 export function className(type: RecordType) {
   return type.name
 }
@@ -23,11 +27,10 @@ export function enumName(type: EnumType) {
 }
 
 function qualifiedNameFor<T extends HasName>(type: T, transform: (T) => string, context: GeneratorContext) {
-  const baseName = transform(type)
   if (context.options.removeNameSpace) {
-    return baseName
+    return transform(type)
   }
-  return type.namespace ? `${type.namespace}.${baseName}` : `${baseName}`
+  return qualifiedName(type, transform)
 }
 
 export function qInterfaceName(type: RecordType, context: GeneratorContext) {
@@ -42,8 +45,12 @@ export function qEnumName(type: EnumType, context: GeneratorContext) {
   return qualifiedNameFor(type, enumName, context)
 }
 
-export function qualifiedName(type: HasName) {
-  return type.namespace ? `${type.namespace}.${type.name}` : type.name
+export function qAvroWrapperName(type: RecordType, context: GeneratorContext) {
+  return qualifiedNameFor(type, avroWrapperName, context)
+}
+
+export function qualifiedName(type: HasName, transform: (e: HasName) => string = (e) => e.name) {
+  return type.namespace ? `${type.namespace}.${transform(type)}` : transform(type)
 }
 
 export function resolveReference(ref: string, context: GeneratorContext): HasName {

--- a/test/classModels/classModels.ts
+++ b/test/classModels/classModels.ts
@@ -4,6 +4,13 @@ export interface IRecordWithArrays {
   simpleArray: string[];
   multiTypeArray: (string | number)[];
 }
+export interface IRecordWithArraysAvroWrapper {
+  simpleArray: string[];
+  multiTypeArray: ({
+    string?: string;
+    int?: number;
+  })[];
+}
 export class RecordWithArrays implements IRecordWithArrays {
   public simpleArray: string[];
   public multiTypeArray: (string | number)[];
@@ -11,10 +18,10 @@ export class RecordWithArrays implements IRecordWithArrays {
     this.simpleArray = input.simpleArray;
     this.multiTypeArray = input.multiTypeArray;
   }
-  public static deserialize(input: any): RecordWithArrays {
+  public static deserialize(input: IRecordWithArraysAvroWrapper): RecordWithArrays {
     return new RecordWithArrays({
-      simpleArray: input.simpleArray.map((e: any) => e),
-      multiTypeArray: input.multiTypeArray.map((e: any) => {
+      simpleArray: input.simpleArray.map((e) => e),
+      multiTypeArray: input.multiTypeArray.map((e) => {
         return (() => {
           if (e['string'] !== undefined) {
             return e['string'];
@@ -26,7 +33,7 @@ export class RecordWithArrays implements IRecordWithArrays {
       }),
     });
   }
-  public static serialize(input: RecordWithArrays): object {
+  public static serialize(input: RecordWithArrays): IRecordWithArraysAvroWrapper {
     return {
       simpleArray: input.simpleArray.map((e) => e),
       multiTypeArray: input.multiTypeArray.map((e) => {
@@ -54,6 +61,10 @@ export interface IDistance {
   amount: number;
   unit: UnitOfDistance;
 }
+export interface IDistanceAvroWrapper {
+  amount: number;
+  unit: UnitOfDistance;
+}
 export class Distance implements IDistance {
   public amount: number;
   public unit: UnitOfDistance;
@@ -61,13 +72,13 @@ export class Distance implements IDistance {
     this.amount = input.amount;
     this.unit = input.unit;
   }
-  public static deserialize(input: any): Distance {
+  public static deserialize(input: IDistanceAvroWrapper): Distance {
     return new Distance({
       amount: input.amount,
       unit: input.unit,
     });
   }
-  public static serialize(input: Distance): object {
+  public static serialize(input: Distance): IDistanceAvroWrapper {
     return {
       amount: input.amount,
       unit: input.unit,
@@ -80,12 +91,15 @@ export class Distance implements IDistance {
 export interface IMapValue {
   value: { [index: string]: number };
 }
+export interface IMapValueAvroWrapper {
+  value: { [index: string]: number };
+}
 export class MapValue implements IMapValue {
   public value: { [index: string]: number };
   constructor(input: Partial<IMapValue>) {
     this.value = input.value;
   }
-  public static deserialize(input: any): MapValue {
+  public static deserialize(input: IMapValueAvroWrapper): MapValue {
     return new MapValue({
       value: (() => {
         const keys = Object.keys(input.value);
@@ -99,11 +113,11 @@ export class MapValue implements IMapValue {
       })(),
     });
   }
-  public static serialize(input: MapValue): object {
+  public static serialize(input: MapValue): IMapValueAvroWrapper {
     return {
       value: (() => {
         const keys = Object.keys(input.value);
-        const output: any = {};
+        const output: { [index: string]: number } = {};
         for (let i = 0; i < keys.length; i += 1) {
           const mapKey = keys[i];
           const mapValue = input.value[mapKey];
@@ -129,6 +143,18 @@ export interface IPerson {
   fullname: IFullName;
   addresses: IAddress[];
 }
+export interface IAddressAvroWrapper {
+  city: string;
+  country: string;
+}
+export interface IFullNameAvroWrapper {
+  firstName: string;
+  lastName: string;
+}
+export interface IPersonAvroWrapper {
+  fullname: IFullNameAvroWrapper;
+  addresses: IAddressAvroWrapper[];
+}
 export class Address implements IAddress {
   public city: string;
   public country: string;
@@ -136,13 +162,13 @@ export class Address implements IAddress {
     this.city = input.city;
     this.country = input.country;
   }
-  public static deserialize(input: any): Address {
+  public static deserialize(input: IAddressAvroWrapper): Address {
     return new Address({
       city: input.city,
       country: input.country,
     });
   }
-  public static serialize(input: Address): object {
+  public static serialize(input: Address): IAddressAvroWrapper {
     return {
       city: input.city,
       country: input.country,
@@ -156,13 +182,13 @@ export class FullName implements IFullName {
     this.firstName = input.firstName;
     this.lastName = input.lastName;
   }
-  public static deserialize(input: any): FullName {
+  public static deserialize(input: IFullNameAvroWrapper): FullName {
     return new FullName({
       firstName: input.firstName,
       lastName: input.lastName,
     });
   }
-  public static serialize(input: FullName): object {
+  public static serialize(input: FullName): IFullNameAvroWrapper {
     return {
       firstName: input.firstName,
       lastName: input.lastName,
@@ -176,13 +202,13 @@ export class Person implements IPerson {
     this.fullname = input.fullname;
     this.addresses = input.addresses;
   }
-  public static deserialize(input: any): Person {
+  public static deserialize(input: IPersonAvroWrapper): Person {
     return new Person({
       fullname: FullName.deserialize(input.fullname),
-      addresses: input.addresses.map((e: any) => Address.deserialize(e)),
+      addresses: input.addresses.map((e) => Address.deserialize(e)),
     });
   }
-  public static serialize(input: Person): object {
+  public static serialize(input: Person): IPersonAvroWrapper {
     return {
       fullname: FullName.serialize(input.fullname),
       addresses: input.addresses.map((e) => Address.serialize(e)),
@@ -203,6 +229,27 @@ export interface IHuman {
   firstname: string;
   lastname: string;
 }
+export interface IDogAvroWrapper {
+  name: string;
+  owner: {
+    'com.animals.Human'?: IHumanAvroWrapper;
+  } | null;
+  extra: ({
+    'com.animals.Human'?: IHumanAvroWrapper;
+    'com.animals.Dog'?: IDogAvroWrapper;
+  })[];
+  friend: {
+    'com.animals.Dog'?: IDogAvroWrapper;
+  } | null;
+  other: {
+    'com.animals.Dog'?: IDogAvroWrapper;
+    'com.animals.Human'?: IHumanAvroWrapper;
+  } | null;
+}
+export interface IHumanAvroWrapper {
+  firstname: string;
+  lastname: string;
+}
 export class Dog implements IDog {
   public name: string;
   public owner: null | IHuman;
@@ -216,7 +263,7 @@ export class Dog implements IDog {
     this.friend = input.friend;
     this.other = input.other;
   }
-  public static deserialize(input: any): Dog {
+  public static deserialize(input: IDogAvroWrapper): Dog {
     return new Dog({
       name: input.name,
       owner: (() => {
@@ -227,7 +274,7 @@ export class Dog implements IDog {
         }
         throw new TypeError('Unresolvable type');
       })(),
-      extra: input.extra.map((e: any) => {
+      extra: input.extra.map((e) => {
         return (() => {
           if (e['com.animals.Human'] !== undefined) {
             return Human.deserialize(e['com.animals.Human']);
@@ -257,7 +304,7 @@ export class Dog implements IDog {
       })(),
     });
   }
-  public static serialize(input: Dog): object {
+  public static serialize(input: Dog): IDogAvroWrapper {
     return {
       name: input.name,
       owner: (() => {
@@ -306,13 +353,13 @@ export class Human implements IHuman {
     this.firstname = input.firstname;
     this.lastname = input.lastname;
   }
-  public static deserialize(input: any): Human {
+  public static deserialize(input: IHumanAvroWrapper): Human {
     return new Human({
       firstname: input.firstname,
       lastname: input.lastname,
     });
   }
-  public static serialize(input: Human): object {
+  public static serialize(input: Human): IHumanAvroWrapper {
     return {
       firstname: input.firstname,
       lastname: input.lastname,
@@ -329,17 +376,30 @@ export interface ITree {
   left: null | ITree | ILeaf;
   right: null | ITree | ILeaf;
 }
+export interface ILeafAvroWrapper {
+  value: string;
+}
+export interface ITreeAvroWrapper {
+  left: {
+    'com.company.Tree'?: ITreeAvroWrapper;
+    'com.company.Leaf'?: ILeafAvroWrapper;
+  } | null;
+  right: {
+    'com.company.Tree'?: ITreeAvroWrapper;
+    'com.company.Leaf'?: ILeafAvroWrapper;
+  } | null;
+}
 export class Leaf implements ILeaf {
   public value: string;
   constructor(input: Partial<ILeaf>) {
     this.value = input.value;
   }
-  public static deserialize(input: any): Leaf {
+  public static deserialize(input: ILeafAvroWrapper): Leaf {
     return new Leaf({
       value: input.value,
     });
   }
-  public static serialize(input: Leaf): object {
+  public static serialize(input: Leaf): ILeafAvroWrapper {
     return {
       value: input.value,
     };
@@ -352,7 +412,7 @@ export class Tree implements ITree {
     this.left = input.left;
     this.right = input.right;
   }
-  public static deserialize(input: any): Tree {
+  public static deserialize(input: ITreeAvroWrapper): Tree {
     return new Tree({
       left: (() => {
         if (input.left === null) {
@@ -376,7 +436,7 @@ export class Tree implements ITree {
       })(),
     });
   }
-  public static serialize(input: Tree): object {
+  public static serialize(input: Tree): ITreeAvroWrapper {
     return {
       left: (() => {
         if (input.left === null) {
@@ -413,6 +473,15 @@ export interface IRecordWithPrimitives {
   int: number;
   other: null;
 }
+export interface IRecordWithPrimitivesAvroWrapper {
+  bool: boolean;
+  str: string;
+  long: number;
+  float: number;
+  double: number;
+  int: number;
+  other: null;
+}
 export class RecordWithPrimitives implements IRecordWithPrimitives {
   public bool: boolean;
   public str: string;
@@ -430,7 +499,7 @@ export class RecordWithPrimitives implements IRecordWithPrimitives {
     this.int = input.int;
     this.other = input.other;
   }
-  public static deserialize(input: any): RecordWithPrimitives {
+  public static deserialize(input: IRecordWithPrimitivesAvroWrapper): RecordWithPrimitives {
     return new RecordWithPrimitives({
       bool: input.bool,
       str: input.str,
@@ -441,7 +510,7 @@ export class RecordWithPrimitives implements IRecordWithPrimitives {
       other: input.other,
     });
   }
-  public static serialize(input: RecordWithPrimitives): object {
+  public static serialize(input: RecordWithPrimitives): IRecordWithPrimitivesAvroWrapper {
     return {
       bool: input.bool,
       str: input.str,

--- a/test/classes.spec.ts
+++ b/test/classes.spec.ts
@@ -11,11 +11,20 @@ import {
   Dog,
   Tree,
   Leaf,
+  UnitOfDistance,
+  IPersonAvroWrapper,
+  IMapValueAvroWrapper,
+  IDistanceAvroWrapper,
+  IRecordWithArraysAvroWrapper,
+  IRecordWithPrimitivesAvroWrapper,
+  IHumanAvroWrapper,
+  IDogAvroWrapper,
+  ITreeAvroWrapper,
 } from './classModels/classModels'
 
 describe('Classes', () => {
   it('Should serialize/deserialize primitive types', () => {
-    const input = {
+    const input: IRecordWithPrimitivesAvroWrapper = {
       bool: true,
       double: 1.2,
       float: 3.4,
@@ -30,7 +39,7 @@ describe('Classes', () => {
   })
 
   it('Should serialize/deserialize array types', () => {
-    const input = {
+    const input: IRecordWithArraysAvroWrapper = {
       multiTypeArray: [{ int: 5 }, { string: 'hello' }, { int: 4 }],
       simpleArray: ['he', 'llo', 'world'],
     }
@@ -41,9 +50,9 @@ describe('Classes', () => {
   })
 
   it('Should serialize/deserialize enum types', () => {
-    const input = {
+    const input: IDistanceAvroWrapper = {
       amount: 1,
-      unit: 'miles',
+      unit: UnitOfDistance.miles,
     }
     const parsed = Distance.deserialize(input)
     expect(parsed).to.be.instanceOf(Distance)
@@ -51,7 +60,7 @@ describe('Classes', () => {
   })
 
   it('Should serialize/deserialize map types', () => {
-    const input = {
+    const input: IMapValueAvroWrapper = {
       value: {
         hi: 1,
         hello: 2,
@@ -63,7 +72,7 @@ describe('Classes', () => {
   })
 
   it('Should serialize/deserialize multiple types', () => {
-    const input = {
+    const input: IPersonAvroWrapper = {
       fullname: {
         firstName: 'John',
         lastName: 'Doe',
@@ -80,15 +89,15 @@ describe('Classes', () => {
   })
 
   it('Should serialize/deserialize namespaced types', () => {
-    const human1 = {
+    const human1: IHumanAvroWrapper = {
       firstname: 'Human1',
       lastname: 'Human1',
     }
-    const human2 = {
+    const human2: IHumanAvroWrapper = {
       firstname: 'Human2',
       lastname: 'Human2',
     }
-    const input = {
+    const input: IDogAvroWrapper = {
       name: 'Dog1',
       extra: [{ 'com.animals.Human': human1 }],
       owner: { 'com.animals.Human': human2 },
@@ -108,7 +117,7 @@ describe('Classes', () => {
   })
 
   it('Should serialize/deserialize nested union types', () => {
-    const input = {
+    const input: ITreeAvroWrapper = {
       left: {
         'com.company.Tree': {
           left: {


### PR DESCRIPTION
This commit makes schema generation add avro wrappers, which have the proper typing of the the expected input. This helps getting rid of `any`s in the code.