### PR TITLE
Generator fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ typings/
 
 # rollup cache
 .rpt2_cache
+input.avsc

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,6 +234,15 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "requires": {
+        "snake-case": "2.1.0",
+        "upper-case": "1.1.3"
+      }
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -560,6 +569,11 @@
         "is-buffer": "1.1.6"
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
     "make-error": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
@@ -648,6 +662,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "1.1.4"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -817,6 +839,14 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "requires": {
+        "no-case": "2.3.2"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -933,6 +963,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build-cli": "rollup -c rollup.cli.config.js",
     "build": "npm run build-main && npm run build-cli",
     "test": "mocha -r ts-node/register test/*.spec.ts",
-    "tslint": "tslint -c tslint.json 'src/**/*.ts'"
+    "tslint": "tslint -c tslint.json 'src/**/*.ts'",
+    "run-cli": "npm run build && node dist/cli.js -x -c -f input.avsc > output.ts"
   },
   "repository": {
     "type": "git",
@@ -46,6 +47,7 @@
     "typescript": "^3.0.1"
   },
   "dependencies": {
+    "constant-case": "^2.0.0",
     "minimist": "^1.2.0",
     "prettier": "^1.14.2"
   }

--- a/src/generators/generateAvroWrapper.ts
+++ b/src/generators/generateAvroWrapper.ts
@@ -4,6 +4,7 @@ import {
   qEnumName,
   resolveReference,
   qAvroWrapperName,
+  fqnConstantName,
   qualifiedName,
   enumName,
   className,
@@ -15,9 +16,9 @@ function getTypeKey(type: any, context: GeneratorContext): string {
   if (isPrimitive(type)) {
     return type
   } else if (isEnumType(type)) {
-    return qualifiedName(type, enumName)
+    return context.options.removeNameSpace ? `[${fqnConstantName(type)}]` : qualifiedName(type, enumName)
   } else if (isRecordType(type)) {
-    return qualifiedName(type, className)
+    return context.options.removeNameSpace ? `[${fqnConstantName(type)}]` : qualifiedName(type, className)
   } else if (isArrayType(type) || isMapType(type)) {
     return type.type
   } else if (typeof type === 'string') {

--- a/src/generators/generateClass.ts
+++ b/src/generators/generateClass.ts
@@ -14,11 +14,15 @@ export function generateClass(type: RecordType, context: GeneratorContext): stri
   const assignments =
     type.fields.length === 0
       ? '/* noop */'
-      : type.fields.map((field) => `this.${field.name} = input.${field.name};`).join('\n')
+      : type.fields
+          .map((field) => {
+            return `this.${field.name} = input.${field.name} === undefined ? null : input.${field.name};`
+          })
+          .join('\n')
 
   return `export class ${className(type)} implements ${interfaceName(type)} {
     ${type.fields.map((f) => generateClassFieldDeclaration(f, context)).join('\n')}
-    constructor(input: Partial<${interfaceName(type)}>) {
+    constructor(input: ${interfaceName(type)}) {
       ${assignments}
     }
     ${generateDeserialize(type, context)}

--- a/src/generators/generateContent.ts
+++ b/src/generators/generateContent.ts
@@ -3,18 +3,22 @@ import { generateClass } from './generateClass'
 import { generateEnumType } from './generateEnum'
 import { generateAvroWrapper } from './generateAvroWrapper'
 import { alphaComparator } from './utils'
-import { RecordType, EnumType } from '../model'
+import { RecordType, EnumType, HasName } from '../model'
 import { GeneratorContext } from './typings'
+import { generateFqnConstant } from './generateFqnConstants'
 
 export function generateContent(recordTypes: RecordType[], enumTypes: EnumType[], context: GeneratorContext) {
   const sortedEnums = enumTypes.sort(alphaComparator)
   const sortedRecords = recordTypes.sort(alphaComparator)
+  const all: HasName[] = [].concat(sortedEnums, sortedRecords)
 
+  const fqns = context.options.removeNameSpace ? all.map(generateFqnConstant) : []
   const enums = sortedEnums.map((t) => generateEnumType(t, context))
   const interfaces = sortedRecords.map((t) => generateInterface(t, context))
   const avroWrappers = sortedRecords.map((t) => generateAvroWrapper(t, context))
   const classes = sortedRecords.map((t) => generateClass(t, context))
   return []
+    .concat(fqns)
     .concat(enums)
     .concat(interfaces)
     .concat(avroWrappers)

--- a/src/generators/generateDeserialize.ts
+++ b/src/generators/generateDeserialize.ts
@@ -4,10 +4,11 @@ import {
   asSelfExecuting,
   joinConditional,
   className,
-  qualifiedName,
   resolveReference,
   qClassName,
   avroWrapperName,
+  fqnConstantName,
+  qualifiedName,
 } from './utils'
 import { generateFieldType } from './generateFieldType'
 import { GeneratorContext } from './typings'
@@ -16,7 +17,7 @@ function getKey(t: any, context: GeneratorContext) {
   if (!isPrimitive(t) && typeof t === 'string') {
     return getKey(resolveReference(t, context), context)
   } else if (isEnumType(t) || isRecordType(t)) {
-    return `'${qualifiedName(t)}'`
+    return context.options.removeNameSpace ? fqnConstantName(t) : `'${qualifiedName(t)}'`
   } else {
     return `'${getTypeName(t, context)}'`
   }

--- a/src/generators/generateFqnConstants.ts
+++ b/src/generators/generateFqnConstants.ts
@@ -1,0 +1,6 @@
+import { HasName } from '../model'
+import { fqnConstantName, qualifiedName } from './utils'
+
+export function generateFqnConstant(type: HasName): string {
+  return `export const ${fqnConstantName(type)} = '${qualifiedName(type)}'`
+}

--- a/src/generators/generateSerialize.ts
+++ b/src/generators/generateSerialize.ts
@@ -8,6 +8,7 @@ import {
   qClassName,
   className,
   avroWrapperName,
+  fqnConstantName,
 } from './utils'
 import { GeneratorContext } from './typings'
 import { generateAvroWrapperFieldType } from './generateAvroWrapper'
@@ -16,7 +17,7 @@ function getKey(t: any, context: GeneratorContext) {
   if (!isPrimitive(t) && typeof t === 'string') {
     return getKey(resolveReference(t, context), context)
   } else if (isEnumType(t) || isRecordType(t)) {
-    return `'${qualifiedName(t)}'`
+    return context.options.removeNameSpace ? `[${fqnConstantName(t)}]` : `'${qualifiedName(t)}'`
   } else {
     return `'${getTypeName(t, context)}'`
   }

--- a/src/generators/utils.ts
+++ b/src/generators/utils.ts
@@ -1,5 +1,6 @@
 import { RecordType, isPrimitive, isArrayType, isMapType, isEnumType, isRecordType, HasName, EnumType } from '../model'
 import { GeneratorContext } from './typings'
+const constantCase = require('constant-case')
 
 export function alphaComparator(a: HasName, b: HasName) {
   if (a.name < b.name) {
@@ -24,6 +25,10 @@ export function className(type: RecordType) {
 
 export function enumName(type: EnumType) {
   return type.name
+}
+
+export function fqnConstantName(type: HasName) {
+  return `${constantCase(type.name)}_FQN`
 }
 
 function qualifiedNameFor<T extends HasName>(type: T, transform: (T) => string, context: GeneratorContext) {


### PR DESCRIPTION
- Constructor now doesn't take `Partial` inputs
- Convenience for constructors: Missing properties now automatically changed to null
- Generated output size reduction: FQNs are now referenced by short constant name (only no namespace mode)